### PR TITLE
Fix OAuth2 URLs in authentik.yml

### DIFF
--- a/web/public/oauth2/authentik.yml
+++ b/web/public/oauth2/authentik.yml
@@ -1,8 +1,8 @@
 name: 'Authentik'
 description: null
-auth_url: 'https://id.example.com/application/o/authorize'
-token_url: 'https://id.example.com/application/o/token'
-info_url: 'https://id.example.com/application/o/userinfo'
+auth_url: 'https://id.example.com/application/o/authorize/'
+token_url: 'https://id.example.com/application/o/token/'
+info_url: 'https://id.example.com/application/o/userinfo/'
 scopes:
   - 'openid'
   - 'email'


### PR DESCRIPTION
Quick little webedit as I ran into this while setting up Calagopus.
Authentik's OAuth2 endpoints seem to require trailing slashes, otherwise Authentik will respond with a 404 Not Found error.
Endpoint documentation for reference: https://docs.goauthentik.io/add-secure-apps/providers/oauth2/#oauth2-endpoints-and-bindings

Tested against Authentik 2026.2.2