### PR TITLE
use docker compose service name for db export, rewrite OOBE warning, switch env codeblocks to txt

### DIFF
--- a/web/docs/advanced/migrating/instances/calagopus-dockerized.md
+++ b/web/docs/advanced/migrating/instances/calagopus-dockerized.md
@@ -201,6 +201,3 @@ The database was not imported correctly, or the wrong database was targeted. Sto
 
 **Login fails / encrypted data appears corrupted:**
 Your `APP_ENCRYPTION_KEY` in `docker-compose.yml` probably doesn't match the one from your original installation. Stop the stack, correct the key and run `docker compose up -d` again.
-
-**`calagopus-db-1` container not found:**
-The container name is generated from your directory name. Check the actual name with `docker compose ps` and adjust the import command accordingly.

--- a/web/docs/advanced/migrating/instances/calagopus-standalone.md
+++ b/web/docs/advanced/migrating/instances/calagopus-standalone.md
@@ -171,6 +171,3 @@ The database was not imported correctly. Stop the panel with `systemctl stop cal
 
 **Login fails / encrypted data appears corrupted:**
 The `APP_ENCRYPTION_KEY` in `/etc/calagopus/.env` does not match the one from your Docker installation. Stop the panel, correct the key, and start it again.
-
-**`calagopus-db-1` container not found:**
-The container name is generated from your compose directory name. Check the actual name with `docker compose ps` and adjust the export command accordingly.

--- a/web/docs/advanced/migrating/instances/calagopus-standalone.md
+++ b/web/docs/advanced/migrating/instances/calagopus-standalone.md
@@ -19,9 +19,47 @@ Make sure you have:
 - The Calagopus binary installed but not yet configured - you need to land on the OOBE screen and stop there
 
 ::: warning Don't click through the OOBE
+The OOBE creates database records that can conflict with the import. If you've already clicked through, drop and recreate the database first.
 ![Calagopus Panel OOBE](../../../panel/oobe.webp)
-The binary install needs an empty database to write into on first run. Stop at the OOBE screen and come back here.
-:::
+
+::: details I already clicked through - how do I undo it?
+You'll need to drop and recreate the database. Pick the matching tab for how Calagopus is installed:
+
+::::tabs
+=== APT/RPM, Binary
+Stop Calagopus first:
+```bash
+# Linux
+systemctl stop calagopus-panel
+
+# Windows
+nssm stop "Calagopus Panel"
+```
+
+Connect to Postgres and recreate the database:
+```bash
+# Linux/MacOS
+sudo -u postgres psql
+
+# Windows: see the binary install guide for psql access
+# https://calagopus.com/docs/panel/installation/binary#database-configuration
+```
+```sql
+DROP DATABASE panel WITH (FORCE);
+CREATE DATABASE panel OWNER calagopus;
+GRANT ALL PRIVILEGES ON DATABASE panel TO calagopus;
+exit
+```
+
+Start Calagopus back up:
+```bash
+# Linux
+systemctl start calagopus-panel
+
+# Windows
+nssm start "Calagopus Panel"
+```
+::::
 
 
 ## Collect values from your existing installation
@@ -48,12 +86,12 @@ Keep both values handy. You'll need them shortly.
 Open `/etc/calagopus/.env` on your target host and set the following values.
 
 Set `APP_ENCRYPTION_KEY` to the value copied above:
-```env
+```txt
 APP_ENCRYPTION_KEY=Ab3xZ9qR2mKp7vLw
 ```
 
 Set `DATABASE_URL` to point at your host PostgreSQL instance. Use the same password from your Docker setup, or a new one if you prefer. Just make sure it matches what you set when creating the database user:
-```env
+```txt
 DATABASE_URL="postgresql://calagopus:yourPassword@localhost:5432/panel"
 ```
 
@@ -68,15 +106,14 @@ docker exec calagopus-db-1 pg_dump \
   -F c \
   -f /tmp/panel.backup
 
-docker cp calagopus-db-1:/tmp/panel.backup ./panel.backup
+docker compose cp db:/tmp/panel.backup ./panel.backup
 ```
 
 This copies the dump out of the container to `./panel.backup` on your host.
 
-::: info
-If you're migrating to a different host, copy `panel.backup` to that machine before continuing.
+::: info Migrating to a different host?
+Copy `panel.backup` to `/opt/calagopus/` on the target machine before continuing.
 :::
-
 
 ## Import the database into the host PostgreSQL
 First, make sure the database user and database exist. Connect to PostgreSQL:


### PR DESCRIPTION
- use `docker compose cp db` instead of hardcoded container name for db export
- rewrite OOBE warning in docker-to-standalone guide
- switch env codeblocks to txt to avoid vitepress parser warnings

**yes.**