### PR TITLE
fix: correct discord.yml oauth template (wrong info_url/paths)

### DIFF
--- a/web/public/oauth2/discord.yml
+++ b/web/public/oauth2/discord.yml
@@ -2,13 +2,13 @@ name: 'Discord'
 description: null
 auth_url: 'https://discord.com/oauth2/authorize'
 token_url: 'https://discord.com/api/oauth2/token'
-info_url: 'https://discord.com/api/oauth2/@me'
+info_url: 'https://discord.com/api/users/@me'
 scopes:
   - 'email'
   - 'identify'
-identifier_path: '$.user.id'
-email_path: '$.user.email'
-username_path: '$.user.username'
+identifier_path: '$.id'
+email_path: '$.email'
+username_path: '$.username'
 name_first_path: null
 name_last_path: null
 enabled: true


### PR DESCRIPTION
## Fix broken Discord OAuth template

### Problem

The bundled `discord.yml` OAuth template (`web/public/oauth2/discord.yml`) points `info_url` at:

```
https://discord.com/api/oauth2/@me
```

This endpoint returns Discord's **OAuth2 authorization object** — `application`, `scopes`, `expires`, and a partial `user` sub-object. That partial `user` object never includes an `email` field, regardless of which scopes were granted.

As a result, any panel using this template fails on every Discord login with:

```json
{"errors":["unable to extract email from Object {...}"]}
```

### Root cause

The correct endpoint for fetching profile data (including `email`, when the `email` scope is granted and the account has a verified email) is:

```
https://discord.com/api/users/@me
```

This endpoint returns the user object directly at the top level, **not** nested under `"user"` — so `identifier_path`, `email_path`, and `username_path` also need `user.` stripped from them or they'll fail to resolve even after fixing `info_url`.

### Fix

```diff
- info_url: 'https://discord.com/api/oauth2/@me'
+ info_url: 'https://discord.com/api/users/@me'

- identifier_path: '$.user.id'
- email_path: '$.user.email'
- username_path: '$.user.username'
+ identifier_path: '$.id'
+ email_path: '$.email'
+ username_path: '$.username'
```

### Testing

Verified against a live panel instance — after applying this change and re-importing the provider, Discord OAuth login/link correctly extracts `id`, `email`, and `username`, and the previous `unable to extract email` error no longer occurs.